### PR TITLE
hook shutdown

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -155,12 +155,13 @@ Hook.prototype.connect = function(options, cb) {
   if (cb==null && options && options instanceof Function )
     cb = options;
   cb = cb || function () {};
+  options = options|| {};
   var self = this;
   
   // since we using reconnect, will callback rightaway
   cb();
   
-  var client = this._client = new nssocket.NsSocket({reconnect: true});
+  var client = this._client = new nssocket.NsSocket({reconnect: options.reconnect});
   client.connect(self['hook-port'], self['hook-host']);
   
   // when connection started we sayng hello and push
@@ -214,13 +215,14 @@ Hook.prototype.start = function(options, cb) {
   if (cb==null && options && options instanceof Function )
     cb = options;
   cb = cb || function () {};
+  options = options || {};
   	
   var self = this;
 
   this.listen(function(e) {
     if (e!=null && (e.code == 'EADDRINUSE' || e.code == 'EADDRNOTAVAIL')) {
       // if server start fails we attempt to start in client mode
-      self.connect(cb);
+      self.connect(options, cb);
     } else {
       cb(e);
     }


### PR DESCRIPTION
Hello, in order to have a nice shutdown for hooks, we need to stop garbage collector timer.

Here is an example (doesn't work before patch, ok after).

``` .javascript
 var Hook = require('tinyhook').Hook;


hook1 = new Hook({name:'hook1'});
hook1.on('*::alive', function(data) {
    console.log('hook1 receives alive');
  });
hook1.start();

hook2 = new Hook({name:'hook2'});
hook2.start({reconnect:false});

hook2.on('hook::ready', function() {
    console.log('hook2 ready');
    hook2.emit('alive', 'toto');
  });


setTimeout(function() {
    hook2.stop(function() {
        console.log('hook2 stopped');
      });
  }, 1000);
setTimeout(function() {
    hook1.stop(function(){
        console.log('hook1 stoppped');
      });
  }, 2000);

```
